### PR TITLE
urcheon: produce DELETED file and translate symlinks

### DIFF
--- a/Urcheon/Action.py
+++ b/Urcheon/Action.py
@@ -245,13 +245,12 @@ class Action():
 		head = self.getFileNewName()
 		body = self.getBody()
 
-		if body:
-			# always write paktrace, even if head is the only body part because
-			# the prepare stage clean-up needs to track all produced files
-			# except in nested build of course since they are already tracked
-			if not self.is_nested:
-				head = self.getFileNewName()
-				self.paktrace.write(self.file_path, head, body)
+		# always write paktrace, even if head is the only body part because
+		# the prepare stage clean-up needs to track all produced files
+		# except in nested build of course since they are already tracked
+		if not self.is_nested:
+			head = self.getFileNewName()
+			self.paktrace.write(self.file_path, head, body)
 
 		unit = {
 			"head": head,

--- a/Urcheon/Action.py
+++ b/Urcheon/Action.py
@@ -811,7 +811,7 @@ class PrevRun(Action):
 		unit_list = []
 		for head in self.preview_list:
 			body = [ head ]
-			self.paktrace.write(head, body)
+			self.paktrace.write(self.file_path, head, body)
 
 			unit = {
 				"head": head,

--- a/Urcheon/Action.py
+++ b/Urcheon/Action.py
@@ -926,6 +926,8 @@ class MergeBsp(DumbTransient):
 		# once the first run is done for one file, it's done
 		# for others files too
 
+		# FIXME: Add other files to the paktrace.
+
 		# TODO: ensure bsp is already copied/compiled if modifying copied/compiled bsp
 		# TODO: this is not yet possible to merge over something built
 		# Ui.warning("Bsp file already there, will reuse: " + source_path)

--- a/Urcheon/Pak.py
+++ b/Urcheon/Pak.py
@@ -317,6 +317,9 @@ class Builder():
 						produced_file_list.append(part)
 
 			# if multiple calls produce the same files (like merge_bsp)
+			# FIXME: that can't work, this is probably a leftover
+			# or we may have to do “if head in body” instead.
+			# See https://github.com/DaemonEngine/Urcheon/issues/48
 			if head in unit:
 				continue
 

--- a/Urcheon/Pak.py
+++ b/Urcheon/Pak.py
@@ -262,7 +262,7 @@ class Builder():
 
 					action.thread_count = max(2, cpu_count - child_thread_count)
 
-					# wrapper does: produced_unit_list.append(a.run())
+					# wrapper does: produced_unit_list.extend(action.run())
 					action_thread = Parallelism.Thread(target=self.threadExtendRes, args=(action.run, (), produced_unit_list))
 					action_thread_list.append(action_thread)
 					action_thread.start()

--- a/Urcheon/Repository.py
+++ b/Urcheon/Repository.py
@@ -489,7 +489,7 @@ class BlackList():
 
 
 class Tree():
-	# Always path game_name when nested
+	# Always pass game_name when nested
 	def __init__(self, source_dir, game_name=None, is_nested=False):
 		self.dir = os.path.realpath(source_dir)
 


### PR DESCRIPTION
repository: produce `DELETE` file when building partial dpkdir to tell the engine to ignore files listed there in dependencies of the package sharing the same base name.

There is a special workaround for building since `unvanquished/0.52.1` to not consider deleted files as a change so it properly writes the DEPS file of `res-players` depending on `0.52` and not `0.52.1` (0.52.1 only deleted files then there is no `res-players_0.52.1` dpk). After that, deleted file may at least produce a dpk with a `DELETED` file listing deleted files, hence producing a dpk.