### PR TITLE
Allow to build packages without config

### DIFF
--- a/Urcheon/Pak.py
+++ b/Urcheon/Pak.py
@@ -66,8 +66,6 @@ class MultiRunner():
 			source_dir = os.path.realpath(source_dir)
 
 			source_tree = Repository.Tree(source_dir, game_name=self.game_name)
-			if not source_tree.isValid():
-				Ui.error("not a supported tree: " + source_dir)
 
 			if self.stage_name in ["prepare"]:
 				dest_dir = source_dir
@@ -732,8 +730,6 @@ def discover(stage_name):
 		source_dir = os.path.realpath(args.source_dir[0])
 
 		source_tree = Repository.Tree(source_dir, game_name=args.game_name)
-		if not source_tree.isValid():
-			Ui.error("not a supported tree, not going further", silent=True)
 
 		# TODO: find a way to update "prepare" actions too
 		file_list = source_tree.listFiles()
@@ -932,8 +928,6 @@ def clean(stage_name):
 		source_dir = os.path.realpath(source_dir)
 
 		source_tree = Repository.Tree(source_dir, game_name=args.game_name)
-		if not source_tree.isValid():
-			Ui.error("not a supported tree, not going further", silent=True)
 
 		cleaner = Cleaner(source_tree)
 

--- a/Urcheon/Ui.py
+++ b/Urcheon/Ui.py
@@ -17,12 +17,10 @@ _print = print
 
 verbosity = None
 
-
 def laconic(message):
 	if sys.stdout.isatty():
 		message = Fore.GREEN + message + Style.RESET_ALL
 	_print(message)
-
 
 def print(message):
 	if verbosity != "laconic":
@@ -30,14 +28,12 @@ def print(message):
 			message = Fore.GREEN + message + Style.RESET_ALL
 		_print(message)
 
-
 def verbose(message):
 	if verbosity == verbose:
 		if sys.stdout.isatty():
 			message = Style.DIM + message + Style.RESET_ALL
 
 		_print(message)
-
 
 def warning(message):
 	message = "Warning: " + message
@@ -47,17 +43,26 @@ def warning(message):
 
 	_print(message)
 
+def help(message, exit=False):
+	message = "Help: " + message
+
+	if sys.stdout.isatty():
+		message = Fore.MAGENTA + message + Style.RESET_ALL
+
+	_print(message)
+
+	if exit:
+		raise SystemExit()
 
 def notice(message):
 	message = "Notice: " + message
 
 	if sys.stdout.isatty():
-		message = Style.BRIGHT + message + Style.RESET_ALL
+		message = Fore.CYAN + message + Style.RESET_ALL
 
 	_print(message)
 
-
-def error(message, silent=False):
+def error(message, silent=False, exit=True):
 	_message = message
 	message = "Error: " + message
 
@@ -65,7 +70,8 @@ def error(message, silent=False):
 		message = Fore.RED + message + Style.RESET_ALL
 	_print(message)
 
-	if silent:
-		raise SystemExit()
-	else:
-		raise ValueError(_message)
+	if exit:
+		if silent:
+			raise SystemExit()
+		else:
+			raise ValueError(_message)


### PR DESCRIPTION
This make possible to build a package without `.pakinfo/pak.conf` file, or with an incomplete one.

If the name or version keys are missing but the folder is named like `<name>_<version>.dpkdir`, name and version will be guessed from the folder name, if the version string in folder name is `src`, it will relies on git to compute the version (or use some failover version).

If there is no config file or the config file doesn't contain the `game` key, the game will have to be specified on command line, like `--game unvanquished`.