### PR TITLE
Add copy map profile, useful when repackaging

### DIFF
--- a/Urcheon/Action.py
+++ b/Urcheon/Action.py
@@ -910,7 +910,7 @@ class CopyBsp(DumbTransient):
 		shutil.copystat(source_path, bsp_transient_path)
 
 		map_compiler = MapCompiler.Compiler(self.source_tree, map_profile=self.map_profile, is_parallel=self.is_parallel)
-		map_compiler.compile(bsp_transient_path, self.transient_maps_path, stage_done=["bsp", "vis", "light"])
+		map_compiler.compile(bsp_transient_path, self.transient_maps_path, stage_done=["copy", "bsp", "vis", "light"])
 
 		self.buildTransientPath(disabled_action_list=["copy_bsp"])
 

--- a/profile/map/common.conf
+++ b/profile/map/common.conf
@@ -7,3 +7,6 @@ default = "release"
 
 [_q3map2_]
 game="${game}"
+
+[copy]
+copy = { tool="copy" }


### PR DESCRIPTION
It makes possible to build a package containing both `.bsp`, and `.map` file without having to write entries in `.pakinfo/action/build.txt` to mark the map files as to be copied and not compiled if the `--map-profile copy` option is used at build time.