### PR TITLE
urcheon: rewrite layout and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,15 @@ _My lovely granger needs a tender knight to care for his little flower._
 Description
 -----------
 
-This is a toolset to manage and build `pk3` or `dpk` source directories.
+Urcheon is purposed to manage and build source directories to produce game packages like Dæmon engine `dpk` or id Tech engines `pk3` or `pk4`.
 
-This toolset focus on [Unvanquished](http://unvanquished.net) game support, but many things were thought to be extended.
+The primary usage of this toolset is to build of [Unvanquished](http://unvanquished.net) game media files. It was initially  developed and tested against the files from [Interstellar Oasis](https://github.com/interstellar-oasis/interstellar-oasis).
 
-This toolset was initially developed for the [Interstellar Oasis](https://github.com/interstellar-oasis/interstellar-oasis) initiative.
-
-Shipped with Urcheon is the Esquirel tool, this is a toolset to modify `.map` and `.bsp` files. Esquirel is a bit id Tech 3 centric at this time. It works well for Unvanquished at this time and probably with many other games using id Tech 3 map and bsp format.
-
-_Urcheon is the Middle English term for “hedgehog”, used to refer the related ordinary in heraldry._
-
-_Esquirel is the Englo-Norman word for “squirrel”, from the Old French “escurel” who displaced Middle English “aquerne”._
+The Esquirel tool is also shipped with Urcheon, which is a tool to some common editions on `.map` and `.bsp` files. Esquirel is a bit id Tech 3 map and bsp format centric at this time.
 
 
-How to run
-----------
+How to run Urcheon and Esquirel
+-------------------------------
 
 Executables are stored within `bin/` directory, so once you cloned this repository you can add this `bin/` directory to your `$PATH` environment variable to run them easily.
 
@@ -31,77 +25,347 @@ Executables are stored within `bin/` directory, so once you cloned this reposito
 Urcheon help
 ------------
 
-This is where the beast comes. This tool handles assets in repository, to prepare them (editor preview texture generation, sloth-driven shader generation), build them (asset compression, bspdir merge, map compilation), then package them. Each file type (lightmap, skybox, texture, model…) is recognized thanks to some profiles you can extend or modify, picking the optimal compression format for each kind. If needed, you can write explicit rules for some specific files to force some format or blacklist some files. The Urcheon tool becomes more powerful when used in git-tracked asset repositories: it can build partial package given any given git reference (to build a package that contains only things since last release tag for example), and it can automatically computes the package version using tags, commits date, and commit id. It allows to define per-map compilation profile. The asset conversion and compression pass is parallelized to speed-up the process.
 
-Urcheon offers multiple stage.
+### Creating a package source
+
+So you want to make a package, in this example we create a simple resource package that contains a text file. We will name this package `res-helloworld`. The DPK specifications reserves the `_` character as a version separator (can't be used in package name or version string).
+
+We create a folder named `res-helloworld_src.dpkdir` and enter it:
+
+```sh
+mkdir res-helloworld_src.dpkdir
+cd res-helloworld_src.dpkdir
+```
+
+This will be a package for the Unvanquished game so let's configure it this way:
+
+```sh
+mkdir .urcheon
+echo 'unvanquished' > .urcheon/game.txt
+```
+
+We need the package to ship some content, let's add a simple text file:
+
+```sh
+mkdir about
+echo 'Hello world!' > about/helloworld.txt
+```
 
 
-### The `discover` stage
+### Basic package tutorial
 
-This is an optional and not recommended stage, you can use it if you want or need to not rely on automatic action list. This stage produces your action lists, do not forget to use `-n` or `--no-auto` options on `prepare` and `build` stages later!
+Now we can build the package, this will produce another dpkdir you can use with your game, with files being either copied, converted or compiled given the need.
+
+It will be stored as `res-helloworld_src.dpkdir/build/test/res-helloworld_test.dpkdir`, you can tell the game engine to use `res-helloworld_src.dpkdir/build/test` as a pakpath to be able to find the package (example: `daemon -pakpath res-helloworld_src.dpkdir/build/test`).
+
+```sh
+urcheon build
+```
+
+Then we can produce the distributable `dpk` package.
+
+It will be stored as `res-helloworld_src.dpkdir/build/pkg/map-castle_<version>.dpk`. The version will be computed by Urcheon (see below).
+
+you can tell the game engine to use `res-helloworld_src.dpkdir/build/test` as a pakpath to be able to find the package (example: `daemon -pakpath res-helloworld_src.dpkdir/build/test`).
+
+```sh
+urcheon package
+```
+
+We can also pas the dpkdir path to Urcheon, this way:
+
+```sh
+cd ..
+urcheon build res-helloworld_src.dpkdir
+urcheon package res-helloworld_src.dpkdir
+```
+
+
+### Special case of prepared dpkdir
+
+Some packages need to be prepared before being built. This is because some third-party software requires some files to exist in source directories, for example map editors and compilers.
+
+Urcheon can produce `.shader` material files or model formats and others in source directory with the `prepare` command, for such package, the build and package routine is:
+
+```sh
+urcheon prepare <dpkdir>
+urcheon build <dpkdir>
+urcheon package <dpkdir>
+```
+
+
+### Building in an arbitrary folder
+
+As you noticed with our previous example, the built files were produced within the source dpkdir, with this layout:
+
+```
+res-helloworld_src.dpkdir/build/test/res-helloworld_test.dpkdir
+res-helloworld_src.dpkdir/build/pkg/res-helloworld_<version>.dpk
+```
+
+You may not want this, especially if you want to build many package and want to get a single build directory. You can use the `--build-prefix <path>` option to change that, like that:
+
+```
+urcheon --build-prefix build build res-helloworld_src.dpkdir
+urcheon --build-prefix build package res-helloworld_src.dpkdir
+```
+
+You get:
+
+```
+build/test/res-helloworld_test.dpkdir
+build/pkg/res-helloworld_<version>.dpk
+```
+
+
+### Package collection tutorial
+
+A package collection is a folder containing a `src` subdirectory full of source dpkdirs.
+
+Let's create a package collection, enter it and create the basic layout:
+
+```
+mkdir PackageCollection
+cd PackageCollection
+```
+
+To tell Urcheon this folder is a package collection, you just need to create the `.urcheon/collection.txt` file, it just has to exist, en empty file is enough:
+
+```sh
+mkdir .urcheon
+touch .urcheon/collection.txt
+```
+
+Then we create two packages, they must be stored in a subdirectory named `src`:
+
+```
+mkdir src
+
+mkdir src/res-package1_src.dpkdir
+mkdir src/res-package1_src.dpkdir/.urcheon
+echo 'unvanquished' > src/res_package1_src.dpkdir/.urcheon/game.txt
+mkdir src/res-package1_src.dpkdir/about
+echo 'Package 1' > src/res_package1_src.dpkdir/about/package1.txt
+
+mkdir src/res-package2_src.dpkdir
+mkdir src/res-package2_src.dpkdir/.urcheon
+echo 'unvanquished' > src/res_package2_src.dpkdir/.urcheon/game.txt
+mkdir src/res-package2_src.dpkdir/about
+echo 'Package 2' > src/res_package1_src.dpkdir/about/package2.txt
+
+urcheon build src/*.dpkdir
+urcheon package src/*.dpkdir
+```
+
+You'll get this layout:
+
+```
+build/test/res-package1_test.dpkdir
+build/test/res-package2_test.dpkdir
+build/pkg/res-package1_<version>.dpk
+build/pkg/res-package2_<version>.dpk
+```
+
+You'll be able to use `build/test` or `build/pkg` as pakpath to make the game engine able to find those packages, example: `daemon -pakpath PackageCollection/build/test` or `daemon -pakpath PackageCollection/build/pkg`.
+
+
+### Delta package building
+
+Urcheon can produce partial packages relying on older versions of the same package. To be able to do that you need to have your dpkdirs stored in git repositories with version computed from git repositories.
+
+You pass the old reference with the `--reference` build option followed by the git reference (for example a git tag), this way:
+
+```sh
+urcheon build --reference <tag> <dpkdir>
+urcheon package <dpkdir>
+```
+
+
+### Dealing with multiple collections
+
+When building dpkdirs from a collection requiring dpkdirs from another collection, one can set the `PAKPATH` environment variable this way (the separator is `;` on Windows and `:` on every other operating system):
+
+```sh
+export PAKPATH=Collection1/src:Collection2/src:Collection3/src
+```
+
+
+### Real life examples
+
+Here we clone the [UnvanquishedAssets](https://github.com/UnvanquishedAssets/UnvanquishedAssets) repository, prepare, build and package it:
+
+```sh
+git clone --recurse-submodules \
+   https://github.com/UnvanquishedAssets/UnvanquishedAssets.git
+
+urcheon prepare UnvanquishedAssets/src/*.dpkdir
+urcheon build UnvanquishedAssets/src/*.dpkdir
+urcheon package UnvanquishedAssets/src/*.dpkdir
+```
+
+We can load the Unvanquished game with the stock plat23 map this way:
+
+```sh
+daemon -pakpath UnvanquishedAssets/build/pkg +devmap plat23
+```
+
+
+Here we build and package delta Unvanquished packages for `res-` and `tex-` packages, only shipping files modified since Unvanquished 0.52.0, and full packages for map ones:
+
+```sh
+urcheon prepare UnvanquishedAssets/src/*.dpkdir
+urcheon build --reference unvanquished/0.52.0 \
+    UnvanquishedAssets/src/res-*.dpkdir \
+    UnvanquishedAssets/src/tex-*.dpkdir
+urcheon build UnvanquishedAssets/src/map-*.dpkdir
+urcheon package UnvanquishedAssets/src/*.dpkdir
+```
+
+Here we clone the [InterstellarOasis](https://github.com/InterstellarOasis/InterstellarOasis) and build it.
+
+Since it needs to access dpkdirs from UnvanquishedAssets, we set `UnvanquishedAssets/src` as a pakpath using the `PAKPATH` environment variable.
+
+We also need the `UnvanquishedAsset/src` folder to be prepared, but there is no need to prepare `InterstellarOasis/src`, only build and package it:
+
+```sh
+git clone --recurse-submodules \
+   https://github.com/InterstellarOasis/InterstellarOasis.git
+
+export PAKPATH=UnvanquishedAssets/src
+
+urcheon prepare UnvanquishedAssets/src/*.dpkdir
+urcheon build InterstellarOasis/src/*.dpkdir
+urcheon package InterstellarOasis/src/*.dpkdir
+```
+
+Given both `UnvanquishedAssets` and `InterstellarOasis` are built, one can load the Unvanquished game with the third-party atcshd map this way:
+
+```sh
+daemon -pakpath UnvanquishedAssets/build/pkg InterstellarOasis/build/pkg +devmap atcshd
+```
+
+
+### DPK version computation
+
+Urcheon knows how to write the DPK version string, computing it if needed.
+
+The recommended way is to store the dpkdir as a git repository, preferably one repository per dpkdir. Doing this unlock all abilities of Urcheon. It will be able to compute versions from git tag and do delta paks (partial DPK relying on older versions of it).
+
+If the dpkdir is not a git repository, Urcheon provides two ways to set the version string.
+
+One way is to write the version string in the `.urcheon/version.txt` file, like this:
+
+```
+echo '0.1' > .urcheon/version.txt
+```
+
+Urcheon does not implement delta packaging when doing this way (it may be implementable though).
+
+Another way is to set the version string in the dpkdir name.
+
+For example: `res-helloworld_0.1.dpkdir`
+
+This is the least recommended method if you care about version control. Urcheon will never implement delta packaging for this (it's an unsolvable problem).
+
+
+### More about Urcheon abilities
+
+As we seen, this tool can prepare the assets (sloth-driven material generation, iqe compilation), build them (asset compression, bspdir merge, map compilation), then package them
+
+Each file type (lightmap, skybox, texture, model…) is recognized thanks to some profiles you can extend or modify, picking the optimal compression format for each kind.
+
+If needed, you can write explicit rules for some specific files to force some format or blacklist some files.
+
+The Urcheon tool becomes more powerful when used in git-tracked asset repositories: it can build partial package given any given git reference (for example to build a package that contains only things since the previous release tag), and it can automatically computes the package version using tags, commits date, and commit id.
+
+Urcheon also allows to define per-map compilation profile.
+
+The asset conversion and compression pass is heavily parallelized to speed-up the process.
+
+
+## More about Urcheon options and commands
+
+Type `urcheon --help` for help about generic options.
+
+
+### The `discover` command
+
+This is an optional and not recommended command, you can use it if you want or need to not rely on automatic action lists. This stage produces your action lists, do not forget to use `-n` or `--no-auto` options on `prepare` and `build` stages later!
 
 In most case, you don't need it. If you need it, it means you have to fix or extend file detection profiles.
 
-This stage is not recommended since it will add so much noise to your git history each time you add or remove files.
+This stage is not recommended since it will add a lot of noise to your git history each time you add or remove files.
+
+This can be used to debug the automatic action list generation (what Urcheon decides to do for each file).
+
+Type `urcheon discover --help` for help about the specific `discover` command options.
 
 
-### The `prepare` stage
+### The `prepare` command
 
-This is an optional stage to prepare your source directory, it is needed when you have to produce files to feed your map editor or your map compiler, like shader files or preview textures. If your texture package is `sloth` driven, you must define a `slothrun` file per texture set and use the `prepare` stage, you can define some `prevrun` files to produces preview textures.
+This is an optional stage to prepare your source directory, it is needed when you have to produce files to feed your map editor or your map compiler, like material files or models. If your texture package is `sloth` driven, you must define a `slothrun` file per texture set and use the `prepare` stage.
 
 If you need to prepare your source, always call this stage before the `build` one.
 
+Type `urcheon prepare --help` for help about the specific `prepare` command options.
 
-### The `build` stage
 
-This stage is required, it produces for you a testable pakdir with final formats: compressed textures, compiled map etc. If your assets are tracked in a git repository, you can a build partial pakdir using the `-r` or `--reference` options plus an arbitrary past git reference (tag, commit…)
+### The `build` command
 
-You can set a `PAKPATH` environment variable to declare multiple directories containing other pakdir, it's needed if your package relies on other ones. The format is like the good old `PATH` environment variable: _absolute pathes separated with colons_.
+This stage is required, it produces for you a testable pakdir with final formats: compressed textures, compiled map etc. If your assets are tracked in a git repository, you can build a partial pakdir using the `-r` or `--reference` options followed by an arbitrary past git reference (tag, commit…)
+
+You can set a `PAKPATH` environment variable to declare multiple directories containing other pakdir, it's needed if your package relies on other packages that are not in the current collection. The format is like the good old `PATH` environment variable: pathes separated with semicolons on Windows and colons on every other operating system.
 
 If you're building a partial `dpk` package, an extra entry containing your previous package version is added to the `DEPS` file automatically.
 
 You must call this stage before the `package` one.
 
+Type `urcheon build --help` for help about the specific `build` command options.
 
-### The `package` stage
+
+### The `package` command
 
 This stage produces a pak file from your previously built pakdir. Urcheon automatically writes the version string of the produced pak and if your game supports `dpk` format it will automatically rewrites your `DEPS` file with versions from other pakdirs found in `PAKPATH`.
 
+Type `urcheon package --help` for help about the specific `package` command options.
 
-### The `clean` stage
+
+### The `clean` command
 
 This stage is convenient to clean stuff, it has multiple options if you don't want to clean-up everything.
 
+This will delete built files from the source dpkdir if prepared, and from the `build/test` and `build/pkg` folders:
 
-### Example:
-
-Having this `.pakinfo/pak.conf` file in your repository:
-
-```
-[config]
-name = "map-name"
-version = "${ref}"
-game = "unvanquished"
+```sh
+urcheon clean src/<dpkdir>
 ```
 
-Running these commands:
+You can clean those folders selectively:
 
-```
-urcheon clean
-urcheon prepare
-urcheon build --reference v2.1 --map-profile final
-urcheon package
-
+```sh
+urcheon clean --source src/<dpkdir>
+urcheon clean --test src/<dpkdir>
+urcheon clean --package src/<dpkdir>
 ```
 
-Urcheon will clean-up remaining produced bits from the previous build, compute build rules (named _actions_) using the `unvanquished` profile, build your source tree since tag `v2.1`, compile the map using a predefined `final` stage, then package the whole as `map-name_2.1+timestamp+sha1.pk3` because there was some modifications since `v2.1`, otherwise the package would be named `map-name_2.1.pk3`.
+Those special options also exist, here to only clean `build/test` and `build/pkg`: 
 
-Type `urcheon <stage> --help` from some help.
+```sh
+urcheon clean --build src/<dpkdir>
+```
+
+This will only delete built maps from `build/test` (keeping every other build files:
+
+```sh
+urcheon clean --maps src/<dpkdir>
+```
+
+Type `urcheon clean --help` for help about the specific `clean` command options.
 
 
 ### Dependencies
 
-These are the Python3 modules you will need to run `urcheon`: `argparse`, `colorama`, `pillow`, `psutil`, `toml` >= 0.9.0.
+These are the Python3 modules you will need to run `urcheon`: `argparse`, `colorama`, `pillow`, `psutil`, and `toml` >= 0.9.0.
 
 The `urcheon` tool relies on:
 
@@ -111,7 +375,7 @@ The `urcheon` tool relies on:
 - [`cwebp` from Google](https://developers.google.com/speed/webp/docs/cwebp) to convert images to webp format;
 - [`crunch` from Dæmon](https://github.com/DaemonEngine/crunch) to convert images to crn format (the one from BinomialLLC is not compatible and the one from Unity lacks required features);
 - [`opusenc` from Xiph](http://opus-codec.org) to convert sound files to opus format;
-- [`iqmtool` from FTE QuakeWorld](https://sourceforge.net/p/fteqw/code/HEAD/tree/trunk/iqm/) to convert iqe models (the one from Sauerbraten is lacking required features).
+- [`iqmtool` from FTE QuakeWorld](https://sourceforge.net/p/fteqw/code/HEAD/tree/trunk/iqm/) to convert iqe models (the `iqm` one from Sauerbraten is lacking required features).
 - [`sloth`](https://github.com/DaemonEngine/Sloth/) to generate .shader material files.
 
 To summarize:
@@ -123,10 +387,12 @@ To summarize:
 Esquirel help
 -------------
 
-Like Urcheon, Esquirel offers multiple stages.
+Type `esquirel --help` for generic help.
+
+Esquirel offers multiple commands.
 
 
-### The `map` stage
+### The `map` command
 
 It allows to parse some maps (id Tech 3 format only supported at this time): de-numberize them for better diff, export entities as seen in bsp, or substitutes entity keywords using some substitution list you can write yourself.
 
@@ -141,16 +407,16 @@ esquirel map --input-map file.map \
 
 This `esquirel` call updates obsolete entities keywords using the `substitution.csv` list, disabling the entity numbering to make lately diffing easier.
 
-Type `esquirel map --help` for some help.
+Type `esquirel map --help` about the specific `map` command options.
 
 
-### The `bsp` stage
+### The `bsp` command
 
 It allows to edit some bsp (id Tech 3 format only supported at this time): import/export texture lists (this way you can rename them or tweak their surface flags), import/export entities, import/export lightmaps (this way you can repaint them by hand or use them as compressed external instead of internal one), or print some statistics. The best part in the `bsp` stage is the ability to convert a `bsp` to a `bspdir` that contains one file per lump, and some of them are stored in editable text format. These `bspdir` are mergeable back as a new `bsp`, allowing many modification or fixes to maps you lost source for. It allows easy maintenance or port to other games.
 
 Example:
 
-```
+```sh
 esquirel bsp --input-bsp level.bsp \
 	--list-lumps \
 	--output-bspdir level.bspdir
@@ -158,7 +424,15 @@ esquirel bsp --input-bsp level.bsp \
 
 This `esquirel` call converts a `bsp` file to a `bspdir` directory, printing some lump statistics at the same time.
 
-Type `esquirel bsp --help` for some help.
+The reverse operation is:
+
+```sh
+esquirel bsp --input-bspdir level.bspdir \
+	--list-lumps \
+	--output-bsp level.bsp
+```
+
+Type `esquirel bsp --help` about the specific `bsp` command options.
 
 
 Warning
@@ -170,10 +444,18 @@ No warranty is given, use this at your own risk. It can make you awesome in spac
 Author
 ------
 
-Thomas Debesse <dev@illwieckz.net>
+Thomas Debesse <hidden email="dev@illwieckz.net"/>
 
 
 Copyright
 ---------
 
 This toolbox is distributed under the highly permissive and laconic [ISC License](COPYING.md).
+
+
+Trivia
+------
+
+_Esquirel is the Englo-Norman word for “squirrel”, from the Old French “escurel” who displaced Middle English “aquerne”._
+
+_Urcheon is the Middle English term for “hedgehog”, used to refer the related ordinary in heraldry._

--- a/Urcheon/Action.py
+++ b/Urcheon/Action.py
@@ -36,8 +36,11 @@ class List():
 		self.source_tree = source_tree
 		self.source_dir = source_tree.dir
 		self.game_name = source_tree.game_name
+
+		config_dir = Default.getPakConfigDir(self.source_dir)
+
 		action_list_file_name = os.path.join(Default.action_list_dir, stage_name + Default.action_list_ext)
-		self.action_list_file_path = os.path.join(Default.pakinfo_dir, action_list_file_name)
+		self.action_list_file_path = os.path.join(config_dir, action_list_file_name)
 		self.action_list_path = os.path.join(self.source_dir, self.action_list_file_path)
 
 		self.inspector = Repository.Inspector(self.source_tree, stage_name, disabled_action_list=disabled_action_list)
@@ -136,9 +139,9 @@ class List():
 	def writeActions(self):
 		pak_config_subdir = os.path.dirname(self.action_list_path)
 		if os.path.isdir(pak_config_subdir):
-			logging.debug("found pakinfo subdir: " +  pak_config_subdir)
+			logging.debug("found package configuration subdirectory: " +  pak_config_subdir)
 		else:
-			logging.debug("create pakinfo subdir: " + pak_config_subdir)
+			logging.debug("create package configuration subdirectory: " + pak_config_subdir)
 			os.makedirs(pak_config_subdir, exist_ok=True)
 
 		action_list_file = open(self.action_list_path, "w")
@@ -871,15 +874,7 @@ class DumbTransient(Action):
 		file_tree = Repository.Tree(self.transient_path, game_name=self.game_name, is_nested=True)
 		file_list = file_tree.listFiles()
 
-		### TODO: write better code to write dummy pak.conf
-		transient_pakinfo_dir = os.path.join(self.transient_path, Default.pakinfo_dir)
-		os.mkdir(transient_pakinfo_dir)
-		transient_pakinfo_file_path = os.path.join(transient_pakinfo_dir, "pak" + os.path.extsep + "conf")
-
-		transient_pakinfo_file = open(transient_pakinfo_file_path, 'wt', encoding='utf-8')
-		transient_pakinfo_file.write("[config]")
-		transient_pakinfo_file.close()
-
+		# No need for stub configuration in dummy pak anymore.
 		builder = Pak.Builder(file_tree, None, self.stage_name, self.build_dir, disabled_action_list=disabled_action_list, is_nested=True, is_parallel=False)
 		# keep track of built files
 		produced_unit_list = builder.build()

--- a/Urcheon/Default.py
+++ b/Urcheon/Default.py
@@ -8,32 +8,46 @@
 #
 
 
+import logging
 import os.path
 import sys
 
 profile_dir = "profile"
-pakinfo_dir = ".pakinfo"
-pak_config_base = "pak"
-pak_config_ext = ".conf"
-paktrace_dir = ".paktrace"
+
+legacy_pakinfo_dir = ".pakinfo"
+legacy_setinfo_dir = ".setinfo"
+repository_config_dir = ".urcheon"
+
+cache_dir = ".cache"
+
+legacy_paktrace_dir = ".paktrace"
+paktrace_dir = os.path.join(cache_dir, "urcheon", "paktrace")
 paktrace_file_ext = ".json"
+
 default_base = "common"
+
 game_profile_dir = "game"
 game_profile_ext = ".conf"
+
 map_profile_dir = "map"
 map_profile_ext = ".conf"
+
 sloth_profile_dir = "sloth"
 sloth_profile_ext = ".sloth"
+
 prevrun_profile_dir = "prevrun"
 prevrun_profile_ext = ".prevrun"
+
 slothrun_profile_dir = "slothrun"
 slothrun_profile_ext = ".slothrun"
+
 file_profile_dir = "file"
 file_profile_ext = ".conf"
 action_list_dir = "action"
 action_list_ext = ".txt"
-ignore_list_base = "ignore"
-ignore_list_ext = ".txt"
+
+ignore_list_file = "ignore.txt"
+
 build_prefix = "build"
 source_prefix = "src"
 test_prefix = "test"
@@ -49,3 +63,40 @@ for sub_dir in [".", "share/Urcheon"]:
 	share_dir = os.path.realpath(os.path.join(prefix_dir, sub_dir))
 	if os.path.isdir(os.path.join(share_dir, profile_dir)):
 		break
+
+def getCollectionConfigDir(source_dir):
+	config_dir = os.path.join(source_dir, repository_config_dir)
+	legacy_config_dir = os.path.join(source_dir, legacy_setinfo_dir)
+
+	if os.path.isdir(config_dir):
+		logging.debug("Found collection configuration directory: " + config_dir)
+
+	elif os.path.isdir(legacy_config_dir):
+		logging.debug("Found legacy collection configuration directory: " + legacy_config_dir)
+		config_dir = legacy_config_dir
+
+	return config_dir
+
+def getPakConfigDir(source_dir):
+	config_dir = os.path.abspath(os.path.join(source_dir, repository_config_dir))
+	legacy_config_dir = os.path.abspath(os.path.join(source_dir, legacy_pakinfo_dir))
+
+	if os.path.isdir(config_dir):
+		logging.debug("Found package configuration directory: " + config_dir)
+	elif os.path.isdir(legacy_config_dir):
+		logging.debug("Found legacy package configuration directory: " + config_dir)
+		config_dir = legacy_config_dir
+
+	return config_dir
+
+def getPakTraceDir(build_dir):
+	cache_dir = os.path.abspath(os.path.join(build_dir, paktrace_dir))
+	legacy_cache_dir = os.path.abspath(os.path.join(build_dir, legacy_paktrace_dir))
+
+	if os.path.isdir(cache_dir):
+		logging.debug("Found paktrace cache directory: " + cache_dir)
+	elif os.path.isdir(legacy_cache_dir):
+		logging.debug("Found legacy paktrace cache directory: " + cache_dir)
+		cache_dir = legacy_cache_dir
+
+	return cache_dir

--- a/Urcheon/MapCompiler.py
+++ b/Urcheon/MapCompiler.py
@@ -248,7 +248,7 @@ class Compiler():
 		os.makedirs(self.build_prefix, exist_ok=True)
 
 		self.map_config = Config(self.source_tree, map_path=map_path)
-		self.pakpath_list = Repository.PakVfs().listPakPath()
+		self.pakpath_list = self.source_tree.pak_vfs.listPakPath()
 
 		build_stage_dict = self.map_config.profile_dict[self.map_profile]
 

--- a/Urcheon/Profile.py
+++ b/Urcheon/Profile.py
@@ -20,10 +20,11 @@ class Fs():
 		self.file_dict = {}
 
 		profile_dir = os.path.join(Default.share_dir, Default.profile_dir)
-		pakinfo_dir = os.path.abspath(os.path.join(source_dir , Default.pakinfo_dir))
-
 		self.walk(profile_dir)
-		self.walk(pakinfo_dir)
+
+		config_dir = Default.getPakConfigDir(source_dir)
+		self.walk(config_dir)
+
 		logging.debug("files found: " + str(self.file_dict))
 
 	def walk(self, dir_path):

--- a/Urcheon/Texset.py
+++ b/Urcheon/Texset.py
@@ -378,7 +378,7 @@ class SlothRun():
 			full_path = os.path.realpath(os.path.join(self.source_dir, file_path))
 			sourcedir_file_list.append(full_path)
 
-		# TODO: check also slothrun and sloth files in pakinfo and profiles directories
+		# TODO: check also slothrun and sloth files in .urcheon and profiles directories
 		file_reference_list = sourcedir_file_list
 		file_reference = FileSystem.getNewer(file_reference_list)
 

--- a/Urcheon/Urcheon.py
+++ b/Urcheon/Urcheon.py
@@ -71,7 +71,11 @@ def package(args):
 def clean(args):
 	clean_all = args.clean_all
 
-	if not args.clean_map and not args.clean_build and not args.clean_package and not args.clean_all:
+	if not args.clean_map \
+		and not args.clean_build \
+		and not args.clean_test \
+		and not args.clean_package \
+		and not args.clean_all:
 		clean_all = True
 
 	source_dir_list = args.source_dir
@@ -97,12 +101,12 @@ def clean(args):
 			previous_file_list = paktrace.listAll()
 			cleaner.cleanDust(source_dir, [], previous_file_list)
 
-		if args.clean_build or clean_all:
+		if args.clean_test or args.clean_build or clean_all:
 			pak_config = Repository.Config(source_tree)
 			test_dir = pak_config.getTestDir(build_prefix=args.build_prefix, test_prefix=args.test_prefix, test_dir=args.test_dir)
 			cleaner.cleanTest(test_dir)
 
-		if args.clean_package or clean_all:
+		if args.clean_package or args.clean_build or clean_all:
 			pak_config = Repository.Config(source_tree)
 			pak_prefix = pak_config.getPakPrefix(build_prefix=args.build_prefix, pak_prefix=args.pak_prefix)
 			cleaner.cleanPak(pak_prefix)
@@ -164,9 +168,10 @@ def main():
 	clean_parser.set_defaults(func=clean)
 
 	clean_parser.add_argument("-a", "--all", dest="clean_all", help="clean all (default)", action="store_true")
-	clean_parser.add_argument("-s", "--source", dest="clean_source", help="clean previous source preparation", action="store_true")
-	clean_parser.add_argument("-m", "--map", dest="clean_map", help="clean previous map build", action="store_true")
-	clean_parser.add_argument("-b", "--build", dest="clean_build", help="clean build directory", action="store_true")
+	clean_parser.add_argument("-b", "--build", dest="clean_build", help="clean test directory and generated packages (alias for --test --package)", action="store_true")
+	clean_parser.add_argument("-s", "--source", dest="clean_source", help="clean source directory", action="store_true")
+	clean_parser.add_argument("-t", "--test", dest="clean_test", help="clean test directory", action="store_true")
+	clean_parser.add_argument("-m", "--map", dest="clean_map", help="clean map build", action="store_true")
 	clean_parser.add_argument("-p", "--package", dest="clean_package", help="clean previously generated packages", action="store_true")
 	clean_parser.add_argument("source_dir", nargs="*", metavar="DIRNAME", default=[ "." ], help="clean %(metavar)s directory, default: .")
 


### PR DESCRIPTION
The existing layout was from before urcheon was named urcheon and may have been either too complicated or using meaningless names.

Basically, some design choices were still inherited from the time I prototyped things with shell scripts or early python quick&dirty scripts 8 years ago.

Both `.setinfo` and `.pakinfo` are now named `.urcheon`. It makes obvious in source repositories those folders contain configuration for Urcheon.

## Package configuration

For package configuration the recommended way to set the game name is `.urcheon/game.txt` which is a flat file only containing the single keyword for the game name, as it is far easier to do that:

```sh
echo unvanquished > .urcheon/game.txt
```

Than that:

```sh
cat > .pakinfo/pak.conf <<\EOF
[config]
game = "unvanquished"
EOF
```

Same for the (**strongly discouraged!!!**) `version` variables and the (**now useless!!!**) `name` variables. So instead of doing this:

```sh
cat > .pakinfo/pak.conf <<\EOF
[config]
name = "res-custom"
version = "1.2"
game = "unvanquished"
```

One would do:

```sh
echo 'res-custom' > .urcheon/name.txt
echo '1.2' > .urcheon/version.txt
echo 'unvanquished' > .urcheon/game.txt
```

But _only_ **game** is required!!!

## Collection configuration

The file telling Urcheon a repository is a collection of package and not a package source (like UnvanquishedAssets and InterstellarOasis is now named `.urcheon/collection.txt` instead of `.setinfo/set.conf`.

The `set` name was interesting as it was sort and it was good next to `pak`. It meant “this is a set of package” in a meaning of a collection. But the `set` name can also be ambiguous as it may just mean `setting a configuration` and then `set.conf` or even `set.txt` may have seen it as meaning this is a “configuration” instead of this is a “collection”. I don't like `collection` being a long word to type but I prefer having an explicit word.

The `collection.txt` file is empty, it just has to exist.

This is the collection layout:

```
.urcheon/collection.txt
src/<name>_<version>.dpkdir
```

When building a dpkdir, Urcheon checks if the parent folder is named `src` and has a parent containing `.urcheon/collection.txt`.

As Urcheon did before, when it detects a package collection, it enables the shared build folder for all the packages in the collection and set the pakpath so packages can be built against each others, and deps computation be done by reading other dpkdir git histories.

The `collection.txt` content is reserved for future usage, maybe give the ability to use arbitrary name for the `src` folder (may be useful for Quake 3 mods, this doesn't concern Dæmon based games).

## Cached files

The `.paktrace` folder has now been renamed to `.cache/urcheon/paktrace`.

The paktrace folder is a folder keeping trace of built files (checksum to not rebuild an unmodified file just because git changed the date, keeping track of multiple sources per target, etc.). This is a folder written in build folder but because the `prepare` command actually build some files from the source folder to the source folder (generating `.iqm` models and `.shader` files), prepared packages get this folder written in the source repository (that should be gitignored). Moving `.paktrace` to `.cache` makes more obvious this should not be committed, and using a `.cache` parent folder just enables us to cache more things in the future without having to gitignore more folders.

## Backward compatibility

Urcheon will look for older paths and older file formats before older one, using old configuration of unported packaged and using old paktrace folder of already built files.

The `.gitignore` file in dpkdir repositories would have to be updated to ignore `.cache` instead of `.paktrace`.