### PR TITLE
Strip alpha channel if fully opaque when converting images with crunch, do not let crunch detect normal maps

### DIFF
--- a/Urcheon/Action.py
+++ b/Urcheon/Action.py
@@ -669,7 +669,7 @@ class ConvertCrn(Action):
 
 			image.save(transient_path)
 
-			self.callProcess(["crunch", "-helperThreads", str(self.thread_count), "-file", transient_path] + self.crunch_extra_args + ["-quality", "255", "-out", build_path])
+			self.callProcess(["crunch", "-helperThreads", str(self.thread_count), "-noNormalDetection", "-file", transient_path] + self.crunch_extra_args + ["-quality", "255", "-out", build_path])
 
 			if os.path.isfile(transient_path):
 				os.remove(transient_path)


### PR DESCRIPTION
Crunch doesn't detect opaque alpha channels, so it would convert `RGBA` tga with opaque alpha channel to `DXT5` crn (and may even convert to swizzle formats like `DXT5_AGBR` crn) while the same opaque `RGB` tga would be converted to `DXT1` crn, producing a smaller file with a more common format.