### PR TITLE
urcheon: new layout with pkg, build/pakdir/pkg, build/pkg

### DIFF
--- a/Urcheon/Default.py
+++ b/Urcheon/Default.py
@@ -48,10 +48,18 @@ action_list_ext = ".txt"
 
 ignore_list_file = "ignore.txt"
 
+pkg_dir = "pkg"
+
 build_prefix = "build"
-source_prefix = "src"
-test_prefix = "test"
-pak_prefix = "pkg"
+build_pakdir_folder = "pakdir"
+build_base_prefix = os.path.join(build_prefix, build_pakdir_folder)
+build_pkg_prefix = os.path.join(build_base_prefix, pkg_dir)
+
+package_prefix = build_prefix
+package_pak_folder = ""
+package_base_prefix = os.path.join(package_prefix, package_pak_folder).rstrip("/")
+package_pkg_prefix = os.path.join(package_base_prefix, pkg_dir)
+
 
 prefix_dir = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."))
 

--- a/Urcheon/Pak.py
+++ b/Urcheon/Pak.py
@@ -106,7 +106,7 @@ class Builder():
 			if is_nested:
 				self.test_dir = args.test_dir
 			else:
-				self.test_dir = source_tree.pak_config.getTestDir(build_prefix=args.build_prefix, test_prefix=args.test_prefix, test_dir=args.test_dir, pak_name=args.pak_name)
+				self.test_dir = source_tree.pak_config.getTestDir(args)
 
 			if is_nested:
 				self.since_reference = False
@@ -449,8 +449,8 @@ class Packager():
 		self.allow_dirty = args.allow_dirty
 		self.no_compress = args.no_compress
 
-		self.test_dir = self.pak_config.getTestDir(build_prefix=args.build_prefix, test_prefix=args.test_prefix, test_dir=args.test_dir)
-		self.pak_file = self.pak_config.getPakFile(build_prefix=args.build_prefix, pak_prefix=args.pak_prefix, pak_name=args.pak_name, pak_file=args.pak_file, version_suffix=args.version_suffix)
+		self.test_dir = self.pak_config.getTestDir(args)
+		self.pak_file = self.pak_config.getPakFile(args)
 
 		self.game_profile = Game.Game(source_tree)
 
@@ -616,15 +616,15 @@ class Cleaner():
 		FileSystem.removeEmptyDir(test_dir)
 
 
-	def cleanPak(self, pak_prefix):
-		for dir_name, subdir_name_list, file_name_list in os.walk(pak_prefix):
+	def cleanPak(self, install_dir):
+		for dir_name, subdir_name_list, file_name_list in os.walk(install_dir):
 			for file_name in file_name_list:
 				if file_name.startswith(self.pak_name) and file_name.endswith(self.game_profile.pak_ext):
 					pak_file = os.path.join(dir_name, file_name)
 					Ui.laconic("clean: " + pak_file)
 					os.remove(pak_file)
 					FileSystem.removeEmptyDir(dir_name)
-		FileSystem.removeEmptyDir(pak_prefix)
+		FileSystem.removeEmptyDir(install_dir)
 
 
 	def cleanMap(self, test_dir):


### PR DESCRIPTION
This is something I want to do since years, basically fixing a design issue I made in the very beginning of this project and that is just biting me in the back every now and then. The mistake was to use different base names like `src`, `test` and `pkg` for the various states of the data (source, built, packaged). Now it's always `pkg`, what changes is where the `pkg` folder is stored for every use case (source dpkdir, test dpkdir, release dpk).

------

Instead of using those folders:

```
  src/name_src.dpkdir
  build/test/name_test.dpkdir
  build/pkg/name_<version>.dpk
```

We now use those folders:

```
  pkg/name_src.dpkdir
  build/pakdir/pkg/name_test.dpkdir
  build/pkg/name_<version>.dpk
```

It means the base folder is always `pkg`.

It makes compatibility with legacy idTech tools is better as they expect the same folder name everywhere.

It makes also easier to implement Urcheon compatibility in third party software.

This also make possible to implement compatibility with arbitrary base folder name (like `data` for Xonotic), or even with Quake3-like mods in the future with multiple base folders. This is not a priority but the fact that design makes it possible means it's a better design.

Right now this is good enough for Unvanquished and Dæmon based games.

Data repositories like UnvanquishedAssets or InterstellarOasis have to be migrated this way:

```sh
  [ -d pkg ] && mv pkg pkg.old
  git mv src pkg
  mkdir build/pakdir
  mv build/test build/pakdir/pkg
```

Urcheon doesn't provide any compatibility layer with the previous layout, as the cost of that complexity is considered too high compared to the amounts of repositories to migrates.

```
  urcheon prepare pkg/*.dpkdir
  urcheon build pkg/*.dpkdir
  urcheon package pkg/*.dpkdir
```

The engine can then be run with `-pakpath build/pakdir/pkg` to load dpkdir or be run with `-pakpath package/pkg` to load dpk.

The `--pakprefix` option is now working like the engine `fs_pakprefixes` cvar does, see:

- https://github.com/DaemonEngine/Daemon/pull/964

Some Urcheon-specific environment variables are now prefixed with `URCHEON_`.