### PR TITLE
repository: version_suffix doesn't exist, so don't check it

### DIFF
--- a/Urcheon/Repository.py
+++ b/Urcheon/Repository.py
@@ -388,8 +388,6 @@ class Config():
 				if pak_version == "${ref}":
 					file_repo = Git(self.source_dir, self.game_profile.pak_format)
 					pak_version = file_repo.getVersion(version_suffix=args.version_suffix)
-				elif version_suffix:
-					pak_version += args.version_suffix
 
 				pak_file_name = pak_name + "_" + pak_version + self.game_profile.pak_ext
 


### PR DESCRIPTION
  File "/mnt/media/code/Urcheon/Urcheon/Repository.py", line 391, in getPakFile
    elif version_suffix:
         ^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'version_suffix' where it is not associated with a value

Fixes this runtime error