### PR TITLE
map/profile: use -keeplights like Unvanquished 0.50

### DIFF
--- a/profile/map/daemon.conf
+++ b/profile/map/daemon.conf
@@ -5,41 +5,41 @@
 extend = "common"
 
 [nometa]
-bsp = { tool="q3map2", options="-bsp" }
+bsp = { tool="q3map2", options="-bsp -keeplights" }
 
 [novis]
-bsp = { tool="q3map2", options="-bsp -meta -fastmeta" }
+bsp = { tool="q3map2", options="-bsp -keeplights -meta -fastmeta" }
 
 [nolight]
-bsp = { tool="q3map2", options="-bsp -meta -fastmeta" }
+bsp = { tool="q3map2", options="-bsp -keeplights -meta -fastmeta" }
 vis = { tool="q3map2", options="-vis -fast" }
 
 [nodeluxe]
-bsp = { tool="q3map2", options="-bsp -meta -fastmeta" }
+bsp = { tool="q3map2", options="-bsp -keeplights -meta -fastmeta" }
 vis = { tool="q3map2", options="-vis -fast" }
 light = { tool="q3map2", options="-light -nocollapse -faster -fastallocate -patchshadows -lightmapsize 1024 -external" }
 
 [nosample]
-bsp = { tool="q3map2", options="-bsp -meta -fastmeta" }
+bsp = { tool="q3map2", options="-bsp -keeplights -meta -fastmeta" }
 vis = { tool="q3map2", options="-vis -fast" }
 light = { tool="q3map2", options="-light -nocollapse -faster -fastallocate -patchshadows -deluxe -lightmapsize 1024 -external" }
 
 [nobounce]
-bsp = { tool="q3map2", options="-bsp -meta -fastmeta -maxarea -samplesize 16" }
+bsp = { tool="q3map2", options="-bsp -keeplights -meta -fastmeta -maxarea -samplesize 16" }
 vis = { tool="q3map2", options="-vis" }
 light = { tool="q3map2", options="-light -nocollapse -faster -fastallocate -dirty -dirtscale 0.8 -dirtdepth 32 -patchshadows -samples 2 -samplesize 16 -randomsamples -deluxe -lightmapsize 1024 -external" }
 
 [fast]
-bsp = { tool="q3map2", options="-bsp -meta -fastmeta -maxarea -samplesize 16" }
+bsp = { tool="q3map2", options="-bsp -keeplights -meta -fastmeta -maxarea -samplesize 16" }
 vis = { tool="q3map2", options="-vis" }
 light = { tool="q3map2", options="-light -nocollapse -faster -fastbounce -fastallocate -nobouncestore -shade -dirty -dirtscale 0.8 -dirtdepth 32 -patchshadows -samples 2 -samplesize 16 -randomsamples -bouncegrid -bounce 1 -deluxe -lightmapsize 1024 -external" }
 
 [release]
-bsp = { tool="q3map2", options="-bsp -meta -maxarea -samplesize 8" }
+bsp = { tool="q3map2", options="-bsp -keeplights -meta -maxarea -samplesize 8" }
 vis = { tool="q3map2", options="-vis" }
 light = { tool="q3map2", options="-light -nocollapse -fastbounce -fastallocate -nobouncestore -shade -dirty -dirtscale 0.8 -dirtdepth 32 -patchshadows -samples 3 -samplesize 8 -randomsamples -bouncegrid -bounce 16 -deluxe -lightmapsize 1024 -external" }
 
 [extreme]
-bsp = { tool="q3map2", options="-bsp -meta -maxarea -samplesize 8" }
+bsp = { tool="q3map2", options="-bsp -keeplights -meta -maxarea -samplesize 8" }
 vis = { tool="q3map2", options="-vis" }
 light = { tool="q3map2", options="-light -nocollapse -fastallocate -nobouncestore -shade -dirty -dirtscale 0.8 -dirtdepth 32 -patchshadows -samples 3 -samplesize 8 -randomsamples -bouncegrid -bounce 16 -deluxe -lightmapsize 1024 -external" }

--- a/profile/map/unvanquished.conf
+++ b/profile/map/unvanquished.conf
@@ -5,25 +5,25 @@
 extend = "daemon"
 
 [nobounce]
-bsp = { tool="q3map2", options="-bsp -meta -fastmeta -maxarea -samplesize 16" }
+bsp = { tool="q3map2", options="-bsp -keeplights -meta -fastmeta -maxarea -samplesize 16" }
 vis = { tool="q3map2", options="-vis" }
 light = { tool="q3map2", options="-light -nocollapse -faster -fastallocate -dirty -dirtscale 0.8 -dirtdepth 32 -patchshadows -samples 2 -samplesize 16 -randomsamples -deluxe -lightmapsize 1024 -external" }
 minimap = { tool="q3map2", options="-minimap" }
 
 [fast]
-bsp = { tool="q3map2", options="-bsp -meta -fastmeta -maxarea -samplesize 16" }
+bsp = { tool="q3map2", options="-bsp -keeplights -meta -fastmeta -maxarea -samplesize 16" }
 vis = { tool="q3map2", options="-vis" }
 light = { tool="q3map2", options="-light -nocollapse -faster -fastbounce -fastallocate -nobouncestore -shade -dirty -dirtscale 0.8 -dirtdepth 32 -patchshadows -samples 2 -samplesize 16 -randomsamples -bouncegrid -bounce 1 -deluxe -lightmapsize 1024 -external" }
 minimap = { tool="q3map2", options="-minimap" }
 
 [release]
-bsp = { tool="q3map2", options="-bsp -meta -maxarea -samplesize 8" }
+bsp = { tool="q3map2", options="-bsp -keeplights -meta -maxarea -samplesize 8" }
 vis = { tool="q3map2", options="-vis" }
 light = { tool="q3map2", options="-light -nocollapse -fastbounce -fastallocate -nobouncestore -shade -dirty -dirtscale 0.8 -dirtdepth 32 -patchshadows -samples 3 -samplesize 8 -randomsamples -bouncegrid -bounce 16 -deluxe -lightmapsize 1024 -external" }
 minimap = { tool="q3map2", options="-minimap" }
 
 [extreme]
-bsp = { tool="q3map2", options="-bsp -meta -maxarea -samplesize 8" }
+bsp = { tool="q3map2", options="-bsp -keeplights -meta -maxarea -samplesize 8" }
 vis = { tool="q3map2", options="-vis" }
 light = { tool="q3map2", options="-light -nocollapse -fastallocate -nobouncestore -shade -dirty -dirtscale 0.8 -dirtdepth 32 -patchshadows -samples 3 -samplesize 8 -randomsamples -bouncegrid -bounce 16 -deluxe -lightmapsize 1024 -external" }
 minimap = { tool="q3map2", options="-minimap" }


### PR DESCRIPTION
The purpose is to make them usable as light origin when casting dynamic shadows.