### PR TITLE
File profiles: ignore `sloth-*.txt` files, also do minor fixes

### DIFF
--- a/profile/file/common.conf
+++ b/profile/file/common.conf
@@ -121,6 +121,14 @@ description = "Common Sloth Description File"
 # handled by slothrun
 build = "ignore"
 
+[common_sloth_Feature]
+inherit = "common_text"
+file_prefix = "sloth-"
+file_ext = ".txt"
+description = "Common Sloth Feature File"
+# handled by slothrun
+build = "ignore"
+
 [common_readme]
 inherit = "common_text"
 file_base = "README"

--- a/profile/file/common.conf
+++ b/profile/file/common.conf
@@ -14,9 +14,7 @@ description = "Pixmap Editor File"
 build = "ignore"
 
 [common_gimp_curves]
-file_ext = [
-	"curves",
-]
+file_ext = ".curves"
 description = "Gimp curves file"
 build = "ignore"
 


### PR DESCRIPTION
Ignore `sloth-*.txt` files, also do minor fixes.