### PR TITLE
Add `compile_ase` and `compile_obj` actions for building map models

### DIFF
--- a/Urcheon/Action.py
+++ b/Urcheon/Action.py
@@ -178,6 +178,7 @@ def list():
 		CopyBsp,
 		CompileBsp,
 		CompileAse,
+		CompileObj,
 		# perhaps one day MergeBsp will be run on a copied bsp
 		# so it must be called after that
 		MergeBsp,
@@ -1123,6 +1124,7 @@ class CompileBsp(DumbTransient):
 class CompileAse(DumbTransient):
 	keyword = "compile_ase"
 	description = "compile to ase format"
+	extension = "ase"
 
 	def effective_run(self):
 		source_path = self.getSourcePath()
@@ -1132,7 +1134,7 @@ class CompileAse(DumbTransient):
 
 		self.createTransientPath()
 
-		Ui.laconic("Compiling to ase: " + self.file_path)
+		Ui.laconic("Compiling to " + self.extension + ": " + self.file_path)
 
 		# Do not copy the map source when building in the source directory as a prepare step.
 		if self.source_dir == self.build_dir:
@@ -1140,7 +1142,7 @@ class CompileAse(DumbTransient):
 		else:
 			stage_done = []
 
-		map_compiler = MapCompiler.Compiler(self.source_tree, map_profile="ase")
+		map_compiler = MapCompiler.Compiler(self.source_tree, map_profile=self.extension)
 		map_compiler.compile(source_path, self.transient_maps_path, stage_done=stage_done)
 
 		os.remove(os.path.join(self.transient_path, bsp_path))
@@ -1155,4 +1157,10 @@ class CompileAse(DumbTransient):
 		return self.switchExtension("bsp")
 
 	def getFileNewName(self):
-		return self.switchExtension("ase")
+		return self.switchExtension(self.extension)
+
+
+class CompileObj(CompileAse):
+	keyword = "compile_obj"
+	description = "compile to obj format"
+	extension = "obj"

--- a/Urcheon/Action.py
+++ b/Urcheon/Action.py
@@ -177,19 +177,9 @@ def list():
 		# and navmesh generation
 		CopyBsp,
 		CompileBsp,
-		CompileAse,
-		CompileObj,
 		# perhaps one day MergeBsp will be run on a copied bsp
 		# so it must be called after that
 		MergeBsp,
-		# those are probably the slowest compression image
-		# formats we know
-		ConvertKtx,
-		ConvertDds,
-		ConvertCrn,
-		ConvertNormalCrn,
-		ConvertLosslessWebp,
-		ConvertLossyWebp,
 		# sloth needs previews to be done before sloth
 		# TODO: be sure Sloth is not called before
 		# all previews are generated
@@ -199,6 +189,18 @@ def list():
 		SlothRun,
 		# usually quick
 		CompileIqm,
+		# compiling a map model may require shaders and other models
+		# being generated first.
+		CompileAse,
+		CompileObj,
+		# those are probably the slowest compression image
+		# formats we know
+		ConvertKtx,
+		ConvertDds,
+		ConvertCrn,
+		ConvertNormalCrn,
+		ConvertLosslessWebp,
+		ConvertLossyWebp,
 		# can take some time but not blocking
 		ConvertVorbis,
 		ConvertOpus,

--- a/Urcheon/MapCompiler.py
+++ b/Urcheon/MapCompiler.py
@@ -162,6 +162,7 @@ class Config():
 			"light": ["vis"],
 			"minimap": ["vis"],
 			"nav": ["vis"],
+			"convert": ["bsp"],
 		}
 
 		for profile_name in self.profile_dict.keys():
@@ -227,6 +228,7 @@ class Compiler():
 	def compile(self, map_path, build_prefix, stage_done=[]):
 		self.map_path = map_path
 		self.build_prefix = build_prefix
+		self.stage_done = stage_done
 		stage_name = None
 		stage_option_list = []
 		self.pakpath_list = []
@@ -365,7 +367,7 @@ class Compiler():
 		extended_option_list = []
 
 		# bsp stage is the one that calls -bsp, etc.
-		for stage in ["bsp", "vis", "light", "minimap", "nav"]:
+		for stage in ["bsp", "vis", "light", "minimap", "nav", "convert"]:
 			if "-" + stage in option_list:
 				stage_name = stage
 				logging.debug("stage name: " + stage_name)
@@ -383,6 +385,8 @@ class Compiler():
 			source_path = bsp_path
 		elif "-minimap" in option_list:
 			source_path = bsp_path
+		elif "-convert" in option_list:
+			source_path = bsp_path
 		else:
 			extended_option_list = ["-prtfile", self.prt_path, "-srffile", self.srf_path, "-bspfile", bsp_path]
 			# TODO: define the name somewhere
@@ -397,7 +401,7 @@ class Compiler():
 				Ui.error("command failed: '" + "' '".join(command_list) + "'")
 
 		# keep map source
-		if "-bsp" in option_list and self.map_config.keep_source:
+		if "-bsp" in option_list and self.map_config.keep_source and "copy" not in self.stage_done:
 			self.copy([])
 
 

--- a/profile/file/daemon.conf
+++ b/profile/file/daemon.conf
@@ -190,6 +190,13 @@ dir_ancestor_name = "maps"
 description = "Map"
 build = "compile_bsp"
 
+[daemon_ase]
+file_ext = "map"
+dir_ancestor_name = "models"
+description = "Map object"
+prepare = "compile_ase"
+build = "copy"
+
 [daemon_bspdir_lump]
 dir_ancestor_name = "maps"
 dir_father_ext = ".bspdir"

--- a/profile/map/common.conf
+++ b/profile/map/common.conf
@@ -14,3 +14,7 @@ copy = { tool="copy" }
 [ase]
 bsp = { tool="q3map2", options="-bsp -meta -patchmeta" }
 convert = { tool="q3map2", options="-convert -format ase" }
+
+[obj]
+bsp = { tool="q3map2", options="-bsp -meta -patchmeta" }
+convert = { tool="q3map2", options="-convert -format obj" }

--- a/profile/map/common.conf
+++ b/profile/map/common.conf
@@ -10,3 +10,7 @@ game="${game}"
 
 [copy]
 copy = { tool="copy" }
+
+[ase]
+bsp = { tool="q3map2", options="-bsp -meta -patchmeta" }
+convert = { tool="q3map2", options="-convert -format ase" }


### PR DESCRIPTION
Some maps are designed as a set of files. Parts of the maps are saved as `.map` files, usually in `models/mapobjects`, and compiled to `.ase` or `.obj` files and then the global map source bakes those models in the final BSP.

Examples of maps built that way are:

- `hangar28` by tvezet (Unvanquished)
- `moteof` by SimonOC (Quake 3)

This adds the `compile_ase` and `compile_obj` actions meant to compile those map objects before compiling the whole map itself.

Those actions are meant to be used as a `prepare` step (doing `urcheon prepare pkg/map-castle_src.dpkdir`) because those MAP models have to be compiled to ASE or OBJ before the level editor loads them. It's a bit similar to us compiling an IQE to an IQM as a `prepare` step. Incidentally that also guarantees the map objects are built before the map itself is built.

By default the output model format is ASE, because all hangar28 models are compiled to ASE and almost all moteof models are compiled to ASE so that looks to be a good default format. One can explicitly write a `compile_obj` action in a `prepare` action file to select the other format, the same way someone can explicitly write a `convert_png` action in a `build` action file to override the default `convert_crn` action for an image.

This is something I had in mind for almost 10 years, but I didn't found time to implement it before.

Once this is merged I have no knowledge of a map Urcheon cannot rebuild, or a map workflow Urcheon cannot sustain.