### PR TITLE
profile/map: keep dirt mapping in “old release” build presets

### DIFF
--- a/profile/map/unvanquished.conf
+++ b/profile/map/unvanquished.conf
@@ -25,13 +25,13 @@ minimap = { tool="q3map2", options="-minimap" }
 [release-before-0-56]
 bsp = { tool="q3map2", options="-bsp -keeplights -meta -maxarea -samplesize 8" }
 vis = { tool="q3map2", options="-vis" }
-light = { tool="q3map2", options="-light -nocollapse -fastbounce -fastallocate -nobouncestore -shade -patchshadows -samples 3 -samplesize 8 -randomsamples -bouncegrid -bounce 16 -deluxe -lightmapsize 1024 -external" }
+light = { tool="q3map2", options="-light -nocollapse -fastbounce -fastallocate -nobouncestore -shade -patchshadows -dirty -dirtscale 0.8 -dirtdepth 32 -samples 3 -samplesize 8 -randomsamples -bouncegrid -bounce 16 -deluxe -lightmapsize 1024 -external" }
 minimap = { tool="q3map2", options="-minimap" }
 
 [release-before-0-52]
 bsp = { tool="q3map2", options="-bsp -keeplights -meta -maxarea -samplesize 8" }
 vis = { tool="q3map2", options="-vis" }
-light = { tool="q3map2", options="-light -nocollapse -fast -fastbounce -fastallocate -nobouncestore -shade -patchshadows -samples 3 -samplesize 8 -randomsamples -bouncegrid -bounce 16 -deluxe -lightmapsize 1024 -external" }
+light = { tool="q3map2", options="-light -nocollapse -fast -fastbounce -fastallocate -nobouncestore -shade -patchshadows -dirty -dirtscale 0.8 -dirtdepth 32 -samples 3 -samplesize 8 -randomsamples -bouncegrid -bounce 16 -deluxe -lightmapsize 1024 -external" }
 minimap = { tool="q3map2", options="-minimap" }
 
 [extreme]


### PR DESCRIPTION
Fix a mistake of mine when editing the build presets, dirt mapping is meant to be kept  in “old release” build presets, to make them “work like before”.