### PR TITLE
urcheon: replace obsolete toml module with builtin tomllib

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Type `urcheon clean --help` for help about the specific `clean` command options.
 
 💡️ The [DaemonMediaAuthoringKit](https://github.com/DaemonEngine/DaemonMediaAuthoringKit) makes easy to set-up a complete production environment with Urcheon, its dependencies, and other tools.
 
-These are the Python3 modules you will need to run `urcheon`: `argparse`, `colorama`, `pillow`, `psutil`, and `toml` >= 0.9.0.
+These are the Python3 modules you will need to run `urcheon`: `argparse`, `colorama`, `pillow`, and `psutil`.
 
 The `urcheon` tool relies on:
 

--- a/Urcheon/Game.py
+++ b/Urcheon/Game.py
@@ -16,9 +16,7 @@ from Urcheon import Ui
 from collections import OrderedDict
 import logging
 import os
-import toml
-
-# FIXME: do we need OrderedDict toml constructor here?
+import tomllib
 
 
 class Game():
@@ -43,8 +41,8 @@ class Game():
 			Ui.error("game profile file not found: " + profile_name)
 
 		logging.debug("reading game profile file " + profile_path)
-		profile_file = open(profile_path, "r")
-		profile_dict = toml.load(profile_file, _dict=OrderedDict)
+		profile_file = open(profile_path, "rb")
+		profile_dict = tomllib.load(profile_file)
 		profile_file.close()
 
 		if "_init_" in profile_dict.keys():

--- a/Urcheon/MapCompiler.py
+++ b/Urcheon/MapCompiler.py
@@ -22,7 +22,7 @@ import sys
 import tempfile
 import time
 import os
-import toml
+import tomllib
 
 
 class Config():
@@ -74,8 +74,8 @@ class Config():
 		config_path = self.profile_fs.getPath(config_file_name)
 
 		logging.debug("reading map config: " + config_path)
-		config_file = open(config_path, "r")
-		config_dict = toml.load(config_file, _dict=OrderedDict)
+		config_file = open(config_path, "rb")
+		config_dict = tomllib.load(config_file)
 		config_file.close()
 
 		if "_init_" in config_dict.keys():
@@ -203,7 +203,7 @@ class Config():
 
 	def printConfig(self):
 		# TODO: order it?
-		print(toml.dumps(self.profile_dict))
+		print(tomllib.dumps(self.profile_dict))
 
 
 class Compiler():

--- a/Urcheon/Repository.py
+++ b/Urcheon/Repository.py
@@ -22,13 +22,12 @@ import json
 import logging
 import operator
 import os
-import toml
+import tomllib
 import re
 import shutil
 import subprocess
 import time
 
-# FIXME: do we need OrderedDict toml constructor here?
 
 dpk_special_files = [
 	"DELETED",
@@ -149,8 +148,8 @@ class Config():
 		logging.debug("reading pak config file " + config_file_path)
 
 		# FIXME: Catch error.
-		config_file = open(config_file_path, "r")
-		config_dict = toml.load(config_file, _dict=OrderedDict)
+		config_file = open(config_file_path, "rb")
+		config_dict = tomllib.load(config_file)
 		config_file.close()
 
 		if not "config" in config_dict.keys():
@@ -451,8 +450,8 @@ class FileProfile():
 			# that's not a typo
 			Ui.error("file profile file not found: " + file_profile_path)
 
-		file_profile_file = open(file_profile_path, "r")
-		file_profile_dict = toml.load(file_profile_file, _dict=OrderedDict)
+		file_profile_file = open(file_profile_path, "rb")
+		file_profile_dict = tomllib.load(file_profile_file)
 		file_profile_file.close()
 
 		if "_init_" in file_profile_dict.keys():
@@ -487,7 +486,7 @@ class FileProfile():
 
 	def printProfile(self):
 		logging.debug(str(self.file_type_dict))
-		print(toml.dumps(self.file_type_dict))
+		print(tomllib.dumps(self.file_type_dict))
 
 	def expandFileType(self, file_type_name):
 		logging.debug("expanding file type: " + file_type_name)

--- a/Urcheon/Texset.py
+++ b/Urcheon/Texset.py
@@ -19,9 +19,7 @@ import os
 import shutil
 import subprocess
 import tempfile
-import toml
-
-# FIXME: do we need OrderedDict toml constructor here?
+import tomllib
 
 
 class PrevRun():
@@ -39,8 +37,8 @@ class PrevRun():
 		self.read(preview_profile_path, real_path = True)
 
 		logging.debug("reading preview profile file: " + preview_profile_fullpath)
-		preview_profile_file = open(preview_profile_fullpath, "r")
-		prevrun_dict = toml.load(preview_profile_file, _dict=OrderedDict)
+		preview_profile_file = open(preview_profile_fullpath, "rb")
+		prevrun_dict = tomllib.load(preview_profile_file)
 		preview_profile_file.close()
 
 		if "dir" not in self.prevrun_dict.keys():
@@ -104,8 +102,8 @@ class PrevRun():
 			Ui.error("prevrun profile file not found: " + prevrun_profile_fullpath)
 
 		logging.debug("reading prevrun profile file: " + prevrun_profile_fullpath)
-		prevrun_profile_file = open(prevrun_profile_fullpath, "r")
-		prevrun_dict = toml.load(prevrun_profile_file, _dict=OrderedDict)
+		prevrun_profile_file = open(prevrun_profile_fullpath, "rb")
+		prevrun_dict = tomllib.load(prevrun_profile_file)
 		prevrun_profile_file.close()
 
 		if "_init_" in prevrun_dict.keys():
@@ -129,7 +127,7 @@ class PrevRun():
 
 	def print(self):
 		logging.debug(str(self.prevrun_dict))
-		print(toml.dumps(self.prevrun_dict))
+		print(tomllib.dumps(self.prevrun_dict))
 
 
 	def walk(self):
@@ -324,8 +322,8 @@ class SlothRun():
 			Ui.error("slothrun profile file not found: " + slothrun_profile_fullpath)
 
 		logging.debug("reading slothrun profile file: " + slothrun_profile_fullpath)
-		slothrun_profile_file = open(slothrun_profile_fullpath, "r")
-		slothrun_dict = toml.load(slothrun_profile_file, _dict=OrderedDict)
+		slothrun_profile_file = open(slothrun_profile_fullpath, "rb")
+		slothrun_dict = tomllib.load(slothrun_profile_file)
 		slothrun_profile_file.close()
 
 		if "_init_" in slothrun_dict.keys():
@@ -349,7 +347,7 @@ class SlothRun():
 
 	def print(self):
 		logging.debug(str(self.slothrun_dict))
-		print(toml.dumps(self.slothrun_dict))
+		print(tomllib.dumps(self.slothrun_dict))
 
 
 	def walk(self):

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
 
           buildInputs = [
             (pkgs.python3.withPackages
-              (ps: [ ps.colorama ps.psutil ps.toml ps.pillow ]))
+              (ps: [ ps.colorama ps.psutil ps.pillow ]))
           ];
 
           propagatedBuildInputs = with pkgs; [

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ argparse
 colorama
 pillow
 psutil
-toml>=0.9.0


### PR DESCRIPTION
Replace obsolete `toml` module with builtin `tomllib`.